### PR TITLE
Add usefull links and update modals

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,1 @@
+REACT_APP_START_URL=http://localhost:6543/grafo-principal/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-
 # Etapa 1: Build
 FROM node:18-bookworm-slim AS build
 
 WORKDIR /app
+ARG REACT_APP_START_URL
+ENV REACT_APP_START_URL=$REACT_APP_START_URL
 
 COPY package*.json ./
 RUN npm ci

--- a/public/Diagramas/MapaDeSitioLineasPR.json
+++ b/public/Diagramas/MapaDeSitioLineasPR.json
@@ -84,7 +84,8 @@
       "id": "node-773c88ff-5690-45a8-b312-83f8e67863e4",
       "data": {
         "label": "Obreras",
-        "themeColor": "default"
+        "themeColor": "default",
+        "url": "https://youtu.be/oHg5SJYRHA0?si=HTFgp3vMRY2oAtgg"
       },
       "position": {
         "x": 241.00395560055392,
@@ -184,7 +185,8 @@
       "id": "node-449093b1-64dd-4451-b42b-3f0d6fd526c6",
       "data": {
         "label": "Comunicación",
-        "themeColor": "default"
+        "themeColor": "default",
+        "url": "http://localhost:8081"
       },
       "position": {
         "x": -83.48154204276601,
@@ -244,7 +246,8 @@
       "id": "node-cd8de5ee-a168-47e6-a0ca-07ebf33c0fad",
       "data": {
         "label": "Alimentación",
-        "themeColor": "default"
+        "themeColor": "default",
+        "url": "http://localhost:8080"
       },
       "position": {
         "x": -83.07547117855759,
@@ -424,7 +427,8 @@
       "id": "node-02ff5806-2dd2-430a-b282-5477dc0aa6dc",
       "data": {
         "label": "Taxonomía",
-        "themeColor": "default"
+        "themeColor": "default",
+        "url": "https://es.wikipedia.org/wiki/Apis_mellifera"
       },
       "position": {
         "x": 759.9463684604958,

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
-import { Add, Delete, SwapHoriz, LineStyle } from '@mui/icons-material';
+import { Add, Delete, SwapHoriz, LineStyle, Edit } from '@mui/icons-material';
 
 interface ContextMenuProps {
   anchorPosition: { x: number; y: number } | null;
   onClose: () => void;
   onCreateNode: () => void;
   onDeleteNode: () => void;
+  onEditNode: () => void; // <-- NUEVO
   onDeleteEdge: () => void;
   onToggleEdgeDirection: () => void;
-  onToggleEdgeType: () => void; // Nueva función para alternar el tipo de línea
+  onToggleEdgeType: () => void;
   selectedNodeForDelete: string | null;
   selectedEdgeForDelete: string | null;
 }
@@ -19,9 +20,10 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   onClose,
   onCreateNode,
   onDeleteNode,
+  onEditNode, // <-- NUEVO
   onDeleteEdge,
   onToggleEdgeDirection,
-  onToggleEdgeType, // Nueva prop
+  onToggleEdgeType,
   selectedNodeForDelete,
   selectedEdgeForDelete,
 }) => {
@@ -32,6 +34,11 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
 
   const handleDeleteNode = () => {
     onDeleteNode();
+    onClose();
+  };
+
+  const handleEditNode = () => {
+    onEditNode();
     onClose();
   };
 
@@ -71,12 +78,20 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
       )}
       
       {selectedNodeForDelete && (
-        <MenuItem onClick={handleDeleteNode}>
-          <ListItemIcon>
-            <Delete />
-          </ListItemIcon>
-          <ListItemText primary="Eliminar Nodo" />
-        </MenuItem>
+        <>
+          <MenuItem onClick={handleDeleteNode}>
+            <ListItemIcon>
+              <Delete />
+            </ListItemIcon>
+            <ListItemText primary="Eliminar Nodo" />
+          </MenuItem>
+          <MenuItem onClick={handleEditNode}>
+            <ListItemIcon>
+              <Edit />
+            </ListItemIcon>
+            <ListItemText primary="Editar Nodo" />
+          </MenuItem>
+        </>
       )}
 
       {selectedEdgeForDelete && (

--- a/src/components/Diagram/DiagramCanvas.tsx
+++ b/src/components/Diagram/DiagramCanvas.tsx
@@ -68,13 +68,16 @@ export const DiagramCanvas: React.FC = () => {
     toggleEdgeDirection,
     setNodes,
     setEdges,
+    openEditModal,
   } = useDiagram();
 
   useEffect(() => {
     const loadDiagram = async () => {
       try {
-        // Intentar cargar el diagrama desde el backend
+  // Intentar cargar el diagrama desde el backend
 	const start_url = process.env.REACT_APP_START_URL;
+	// const start_url = "http://localhost:6543/"; // URL para error y que carge el de respaldo (Mapa del sitio)
+  console.log("start_url", start_url);
 	  if (start_url) {
 	      const response = await fetch(start_url);
 	      if (!response.ok) {
@@ -95,7 +98,7 @@ export const DiagramCanvas: React.FC = () => {
 
         // Cargar el diagrama de respaldo desde public/Diagramas
         try {
-          const fallbackResponse = await fetch('/Diagramas/DiagramaTutorial.json');
+          const fallbackResponse = await fetch('Diagramas/MapaDeSitioLineasPR.json');
           if (!fallbackResponse.ok) {
             throw new Error(`Error al cargar el diagrama de respaldo: ${fallbackResponse.statusText}`);
           }
@@ -143,6 +146,13 @@ export const DiagramCanvas: React.FC = () => {
     closeContextMenu();
   }, [selectedEdgeForDelete, setEdges, closeContextMenu]);
 
+  // Función para abrir el modal de edición desde el menú contextual
+  const handleEditNodeFromContextMenu = React.useCallback(() => {
+    if (selectedNodeForDelete) {
+      openEditModal(selectedNodeForDelete);
+    }
+  }, [selectedNodeForDelete, openEditModal]);
+
   return (
     <div ref={diagramRef} style={{ width: '100%', height: '100vh', position: 'relative' }}>
       <Toolbar
@@ -154,6 +164,10 @@ export const DiagramCanvas: React.FC = () => {
         <ReactFlow
           nodes={nodes}
           edges={edges}
+          onNodeClick={(event, node) => {
+            console.log('Nodo picado:', node.data);
+            console.log("ID del nodo", node.id);
+          }}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
@@ -193,11 +207,12 @@ export const DiagramCanvas: React.FC = () => {
         onClose={closeContextMenu}
         onCreateNode={createNodeFromContextMenu}
         onDeleteNode={deleteNodeFromContextMenu}
+        onEditNode={handleEditNodeFromContextMenu} // <-- NUEVO
         onDeleteEdge={deleteEdgeFromContextMenu}
-        onToggleEdgeDirection={toggleEdgeDirection} // Pasamos la nueva función
+        onToggleEdgeDirection={toggleEdgeDirection}
         selectedNodeForDelete={selectedNodeForDelete}
         selectedEdgeForDelete={selectedEdgeForDelete}
-        onToggleEdgeType={toggleEdgeType} // Pasar funcion de alternar tipo de línea
+        onToggleEdgeType={toggleEdgeType}
       />
 
       <NodeEditModal

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="react-scripts" />
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly REACT_APP_START_URL: string;
+  }
+}


### PR DESCRIPTION
This pull request introduces several improvements to the diagram editor, focusing on enhanced node interactivity, improved context menu functionality, and better configuration for environment-specific URLs. The most significant changes include adding support for editing nodes via the context menu, enabling nodes with URLs to open external links on double-click, updating the fallback diagram loading logic, and making the start URL configurable through environment variables.

**Node interactivity and context menu enhancements:**

* Added an "Edit Node" option to the context menu (`ContextMenu.tsx`), allowing users to open the node edit modal directly from the context menu. The necessary props and handlers were introduced to support this feature. 
* Modified node double-click behavior so that if a node has a `url` property, it opens the link in a new tab instead of opening the edit modal.
* Updated several nodes in `MapaDeSitioLineasPR.json` to include a `url` property, enabling the new double-click behavior for those nodes.

**Diagram loading and configuration:**

* Changed the fallback diagram file to `MapaDeSitioLineasPR.json` instead of `DiagramaTutorial.json`, ensuring the correct backup diagram is loaded when the primary fetch fails.
* Made the diagram start URL configurable via the `REACT_APP_START_URL` environment variable, updating both the `.env.development.example` and `Dockerfile` to support this.
* Added a console log for `start_url` to aid debugging during diagram loading.

**Refactoring and state management:**

* Refactored `useDiagram` to clarify state management for node/edge editing and context menus, and to expose new modal control functions (`openEditModal`, `closeEditModal`). 

**Developer experience:**

* Added a debug log for node clicks in `DiagramCanvas.tsx` to assist with development and troubleshooting.